### PR TITLE
Fix an error on golangci-lint GitHub Action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
-    - name: GolangCI-Lint Action
-      uses: actions-contrib/golangci-lint@v0.1.0
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
       with:
-        args: "run -v ./..."
+        version: v1.29


### PR DESCRIPTION
Fix an error. https://github.com/at-ishikawa/kubectl-fzf/runs/4320510519?check_suite_focus=true

Configuration is from the README on v2.5.2
https://github.com/golangci/golangci-lint-action/tree/v2.5.2